### PR TITLE
Fix plugin marketplace install flow and manifest schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "anthropic-docs",
+  "owner": {
+    "name": "xiaolai"
+  },
+  "description": "Auto-updated multi-skill reference for the Anthropic doc ecosystem (Claude Code, Agent SDK, API, platform features, connectors, Cowork, MCP, and news digests).",
+  "plugins": [
+    {
+      "name": "anthropic-docs",
+      "source": {
+        "source": "github",
+        "repo": "xiaolai/anthropic-docs"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ mistakes at edit time.
 ## Install
 
 ```bash
-/plugin install xiaolai/anthropic-docs
+/plugin marketplace add xiaolai/anthropic-docs
+/plugin install anthropic-docs@anthropic-docs
+/reload-plugins
 ```
 
-(or clone the repo and `/plugin install .` from your local copy)
+(or, to try it locally without installing: clone the repo and run `claude --plugin-dir .` from inside it — session-only, not persistent)
 
 ## Skills
 

--- a/skills/claude-code/SKILL-plugins.md
+++ b/skills/claude-code/SKILL-plugins.md
@@ -109,7 +109,7 @@ A marketplace is a collection of plugins. The `marketplace.json` file at the mar
 ```json
 {
   "name": "my-marketplace",
-  "owner": "acme-corp",
+  "owner": { "name": "acme-corp" },
   "plugins": [
     {
       "name": "code-formatter",


### PR DESCRIPTION
The old README install command (/plugin install xiaolai/anthropic-docs) no longer matches Claude Code's marketplace-based install flow. Add the marketplace.json manifest needed for /plugin marketplace add to work, update the README steps accordingly, and fix the owner field example in SKILL-plugins.md which showed the old bare-string form instead of the required { "name": ... } object.